### PR TITLE
Ensure all Chisel carving groups are displayed in JEI

### DIFF
--- a/src/main/java/com/leclowndu93150/chisel/integration/jei/ChiselJEIPlugin.java
+++ b/src/main/java/com/leclowndu93150/chisel/integration/jei/ChiselJEIPlugin.java
@@ -1,6 +1,7 @@
 package com.leclowndu93150.chisel.integration.jei;
 
 import com.leclowndu93150.chisel.Chisel;
+import com.leclowndu93150.chisel.api.block.ChiselBlockType;
 import com.leclowndu93150.chisel.api.carving.ICarvingGroup;
 import com.leclowndu93150.chisel.carving.CarvingGroup;
 import com.leclowndu93150.chisel.carving.KubeJSCarvingGroup;
@@ -13,10 +14,14 @@ import mezz.jei.api.registration.IRecipeCatalystRegistration;
 import mezz.jei.api.registration.IRecipeCategoryRegistration;
 import mezz.jei.api.registration.IRecipeRegistration;
 import mezz.jei.api.runtime.IJeiRuntime;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.tags.TagKey;
 import net.minecraft.world.item.ItemStack;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -25,6 +30,7 @@ import java.util.Set;
 public class ChiselJEIPlugin implements IModPlugin {
 
     private ChiselRecipeCategory category;
+    private final Set<ResourceLocation> registeredGroupIds = new HashSet<>();
 
     @Override
     public void registerCategories(IRecipeCategoryRegistration registration) {
@@ -34,9 +40,24 @@ public class ChiselJEIPlugin implements IModPlugin {
 
     @Override
     public void registerRecipes(IRecipeRegistration registration) {
-        List<ICarvingGroup> groups = ChiselBlocks.ALL_BLOCK_TYPES.stream()
-                .map(blockType -> (ICarvingGroup) new CarvingGroup(blockType))
-                .toList();
+        registeredGroupIds.clear();
+        List<ICarvingGroup> groups = new ArrayList<>();
+
+        for (ChiselBlockType<?> blockType : ChiselBlocks.ALL_BLOCK_TYPES) {
+            groups.add(new CarvingGroup(blockType));
+            registeredGroupIds.add(blockType.getCarvingGroupTag().location());
+        }
+
+        BuiltInRegistries.BLOCK.getTagNames()
+                .map(TagKey::location)
+                .filter(loc -> loc.getNamespace().equals(Chisel.MODID)
+                        && loc.getPath().startsWith("carving/")
+                        && !registeredGroupIds.contains(loc))
+                .toList()
+                .forEach(loc -> {
+                    groups.add(new KubeJSCarvingGroup(loc, Collections.emptySet()));
+                    registeredGroupIds.add(loc);
+                });
 
         registration.addRecipes(ChiselRecipeCategory.RECIPE_TYPE, groups);
     }
@@ -57,14 +78,9 @@ public class ChiselJEIPlugin implements IModPlugin {
                 List<ICarvingGroup> kubeJSGroups = new ArrayList<>();
 
                 for (Map.Entry<ResourceLocation, Set<ResourceLocation>> entry : kubeGroups.entrySet()) {
-                    boolean isExistingGroup = ChiselBlocks.ALL_BLOCK_TYPES.stream()
-                            .anyMatch(bt -> {
-                                ResourceLocation groupId = Chisel.id("carving/" + bt.getName());
-                                return groupId.equals(entry.getKey());
-                            });
-
-                    if (!isExistingGroup) {
+                    if (!registeredGroupIds.contains(entry.getKey())) {
                         kubeJSGroups.add(new KubeJSCarvingGroup(entry.getKey(), entry.getValue()));
+                        registeredGroupIds.add(entry.getKey());
                     }
                 }
 


### PR DESCRIPTION
Expands JEI integration to include carving groups defined purely by datapack block tags. Previously, only groups explicitly tied to `ChiselBlockType` or directly added by KubeJS were registered.
Improves duplicate detection by tracking all registered group IDs.